### PR TITLE
[PAY-5880] django 4 migration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 5):
 
 
 setup(name='postgres-audit-triggers',
-      version='1.2.1',
+      version='1.2.2',
       author='Jared Hobbs',
       author_email='jared.hobbs@carta.com',
       license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info < (3, 5):
     print('Sorry, this module only works on 3.5+')
     sys.exit(1)
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 dev_version_suffix = os.getenv("DEV_VERSION_SUFFIX", "")
 
 setup(name='postgres-audit-triggers',


### PR DESCRIPTION
Error 

```
    return super().handle(*app_labels, **options)
  File "/home/circleci/.pyenv/versions/3.10.2/lib/python3.10/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
  File "/home/circleci/.pyenv/versions/3.10.2/lib/python3.10/site-packages/django/core/management/commands/makemigrations.py", line 235, in handle
    changes = autodetector.changes(
  File "/home/circleci/.pyenv/versions/3.10.2/lib/python3.10/site-packages/django/db/migrations/autodetector.py", line 46, in changes
    changes = self._detect_changes(convert_apps, graph)
  File "/home/circleci/.pyenv/versions/3.10.2/lib/python3.10/site-packages/postgres_audit_triggers/management/commands/makemigrations.py", line 27, in _detect_changes
    self.old_apps = self.from_state.concrete_apps
AttributeError: 'ProjectState' object has no attribute 'concrete_apps'
```

concrete_apps was a property of ProjectState removed in 4.0. 

There is a change the in the migration autodetector code. Please see the link and quoted text for change summaries

[Django 4.0 release notes | Django documentation](https://docs.djangoproject.com/en/5.0/releases/4.0/#migrations-autodetector-changes) 

> The migrations autodetector now uses model states instead of model classes. Also, migration operations for ForeignKey and ManyToManyField fields no longer specify attributes which were not passed to the fields during initialization.

> As a side-effect, running makemigrations might generate no-op AlterField operations for ManyToManyField and ForeignKey fields in some cases.

The code in the postgres_audit_triggers was mainly an override of original method with injection for audit trigger code.

see postgres_audit_triggers/management/commands/makemigrations.py:14


- 4.2 https://github.com/django/django/blob/stable/4.2.x/django/db/migrations/autodetector.py#L1221
- 3.2 https://github.com/django/django/blob/stable/3.2.x/django/db/migrations/autodetector.py#L1008
